### PR TITLE
fix for deprecated and print_teacher_grade_table functions

### DIFF
--- a/class/grade_table.php
+++ b/class/grade_table.php
@@ -71,7 +71,21 @@ class grade_table
     }
 
     /**
-     * 教員用一覧表示
+     * Checks if the user ID is valid and logs an error if it is not.
+     *
+     * @param mixed $user The user object being checked.
+     * @return bool Returns true if the ID is valid, otherwise false.
+     */
+    private function validate_user_id($user) {
+        if (empty($user->id)) {
+            error_log("Error: Missing user->id for the user. User skipped.");
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Teacher list display
      */
     public function print_teacher_grade_table()
     {
@@ -158,6 +172,10 @@ class grade_table
             /* End */
 
             foreach ($users as $user) {
+                if (empty($user->id)) {
+                    error_log("Error: Missing user->id for the user in the function print_teacher_grade_table. User skipped.");
+                    continue;
+                }
                 $agg = $this->va->get_aggregated_grades($user->id);
                 foreach (array(
                              'userid', 'gradebeforeteacher', 'gradebeforeself', 'gradebeforepeer', 'gradebeforeclass',

--- a/class/util.php
+++ b/class/util.php
@@ -5,15 +5,14 @@ defined('MOODLE_INTERNAL') || die();
 
 class util {
     /**
+     * Returns the full name label.
      *
      * @return string
      */
     public static function get_fullname_label() {
-        if (function_exists('get_all_user_name_fields')) {
-            return fullname((object)array_map('get_string', get_all_user_name_fields()));
-        } else {
-            return fullname((object)array_map('get_string',
-                array('firstname' => 'firstname', 'lastname' => 'lastname')));
-        }
+        $userfields = \core_user\fields::for_name()->with_userpic()->get_required_fields_sql('u');
+        $allnamefields = array_flip(\core_user\fields::for_name()->get_required_fields());
+        $namefields = array_intersect_key(array_map('get_string', $allnamefields), $allnamefields);
+        return fullname((object) $namefields);
     }
 }

--- a/class/va.php
+++ b/class/va.php
@@ -2664,11 +2664,7 @@ class va
     public function get_students($userfields = null, $groupid = null)
     {
         if (!$userfields) {
-            if (function_exists('get_all_user_name_fields')) {
-                $userfields = 'u.id, ' . get_all_user_name_fields(true, 'u');
-            } else {
-                $userfields = 'u.id, u.firstname, u.lastname';
-            }
+            $userfields = \core_user\fields::for_identity($this->context)->get_sql('u', false, '', '', false)->selects;
         }
 
         if ($groupid === null) {
@@ -2904,22 +2900,18 @@ class va
     {
         global $DB;
 
-        if (function_exists('get_all_user_name_fields')) {
-            $userfields = 'u.id, ' . get_all_user_name_fields(true, 'u');
-        } else {
-            $userfields = 'u.id, u.firstname, u.lastname';
-        }
+        $userfields = \core_user\fields::for_identity($this->context)->get_sql('u', false, '', '', false)->selects;
 
         if ($sort_manually) {
             $order = ' ORDER BY sortorder ASC';
         }
 
         $contextcourse = \context_course::instance($this->course->id);
-        $params = array(
+        $params = [
             'contextid' => $contextcourse->id,
             'roleid' => 5,
             'courseid' => $this->course->id
-        );
+        ];
 
         if (!empty($groupid)) {
             $join = ' JOIN {groups_members} gm ON gm.userid = u.id';


### PR DESCRIPTION
- Replaced the deprecated `get_all_user_name_fields()` function with the new `\core_user\fields` API across multiple files to ensure compatibility with Moodle 4.3.
- Fixed an issue where the user ID could be missing in the `print_teacher_grade_table` function. An additional check has been implemented to ensure every user has a valid `user->id` before processing. In case of missing ID, an error is logged and the user is skipped. This prevents attempts to write to the database with NULL values for 'userid', improving the module's stability and reliability.