### PR TITLE
Update settings to correct types for executable paths and setting names

### DIFF
--- a/bulkupload/lib.php
+++ b/bulkupload/lib.php
@@ -205,11 +205,11 @@ class videoassessment_bulkupload {
             $base = pathinfo($name, PATHINFO_FILENAME);
             $path = $this->get_tempdir().'/convert/'.$base;
 
-            $videoformat = $CFG->videoassessment_videoformat;
+            $videoformat = $CFG->videoassessment/videoformat;
             $thumbformat = self::THUMBNAIL_FORMAT;
 
             // Convert video.
-            $command = $CFG->videoassessment_ffmpegcommand;
+            $command = $CFG->videoassessment/ffmpegcommand;
             $command = self::fix_ffmpeg_options($command, $videoformat);
             $cmdline = strtr($command, array(
                 '{INPUT}'  => escapeshellarg($srcpath),
@@ -220,7 +220,7 @@ class videoassessment_bulkupload {
                 throw new Exception("failed to execute: $cmdline");
             }
             // Generate thumbnail.
-            $command = $CFG->videoassessment_ffmpegthumbnailcommand;
+            $command = $CFG->videoassessment/ffmpegthumbnailcommand;
             $command = self::fix_ffmpeg_options($command, $thumbformat);
             $cmdline = strtr($command, array(
                 '{INPUT}'  => escapeshellarg($path.$videoformat),
@@ -232,11 +232,11 @@ class videoassessment_bulkupload {
             }
             // Generate a hint track for progressive playback (MP4 only).
             if ($videoformat == '.mp4' &&
-                !empty($CFG->videoassessment_mp4boxcommand)) {
+                !empty($CFG->videoassessment/mp4boxcommand)) {
                 // Network-mounted directories may fail to rename,
                 // so save as a different name and copy & delete.
                 $cmdline = sprintf('%s -hint %s -out %s >%s 2>&1',
-                    $CFG->videoassessment_mp4boxcommand,
+                    $CFG->videoassessment/mp4boxcommand,
                     escapeshellarg($path . $videoformat),
                     escapeshellarg($path . '.hint.mp4'),
                     escapeshellarg($path . '.box.log'));

--- a/classes/va.php
+++ b/classes/va.php
@@ -1164,7 +1164,7 @@ class va {
     private static function get_thumbnail_size() {
         global $CFG;
 
-        if (preg_match('/(\d+)x(\d+)/', $CFG->videoassessment_ffmpegthumbnailcommand, $m)) {
+        if (preg_match('/(\d+)x(\d+)/', $CFG->videoassessment/ffmpegthumbnailcommand, $m)) {
             $size = new \stdClass();
             $size->width = $m[1];
             $size->height = $m[2];

--- a/settings.php
+++ b/settings.php
@@ -39,20 +39,20 @@ if ($ADMIN->fulltree) {
         '.flv'  => '.flv  - Flash Video',
         ];
     $settings->add(
-        new admin_setting_configselect('videoassessment_videoformat',
+        new admin_setting_configselect('videoassessment/videoformat',
             get_string('videoformat', 'videoassessment'),
             get_string('videoformatdesc', 'videoassessment'),
             key($formats), $formats)
         );
 
-    if (!class_exists('admin_setting_configtext_ffmpegcommand')) {
+    if (!class_exists('admin_setting_configexecutable')) {
         /**
          * Custom admin setting for validating ffmpeg command.
          *
          * Validates the ffmpeg command to ensure it contains the required placeholders
          * for input and output file paths.
          */
-        class admin_setting_configtext_ffmpegcommand extends admin_setting_configtext {
+        class admin_setting_configexecutable extends admin_setting_configexecutable {
             /**
              * Validate the ffmpeg command.
              *
@@ -71,21 +71,21 @@ if ($ADMIN->fulltree) {
         }
     }
     $settings->add(
-        new admin_setting_configtext_ffmpegcommand('videoassessment_ffmpegcommand',
+        new admin_setting_configexecutable('videoassessment/ffmpegcommand',
             get_string('ffmpegcommand', 'videoassessment'),
             get_string('ffmpegcommanddesc', 'videoassessment'),
             '/usr/local/bin/ffmpeg -i {INPUT} {OUTPUT}', PARAM_RAW, 60)
         );
 
     $settings->add(
-        new admin_setting_configtext_ffmpegcommand('videoassessment_ffmpegthumbnailcommand',
+        new admin_setting_configexecutable('videoassessment/ffmpegthumbnailcommand',
             get_string('ffmpegthumbnailcommand', 'videoassessment'),
             get_string('ffmpegthumbnailcommanddesc', 'videoassessment'),
             '/usr/local/bin/ffmpeg -i {INPUT} -vframes 1 -s 137x91 -ss 1 {OUTPUT}', PARAM_RAW, 60)
         );
 
     $settings->add(
-        new admin_setting_configtext('videoassessment_mp4boxcommand',
+        new admin_setting_configexecutable('videoassessment/mp4boxcommand',
             get_string('mp4boxcommand', 'videoassessment'),
             get_string('mp4boxcommanddesc', 'videoassessment'),
             '/usr/local/bin/MP4Box', PARAM_RAW, 60)


### PR DESCRIPTION
The settings names were not specified in a way that could be configured in config.php, so they have been renamed. Also, the setting type was changed for the three settings with executable paths so that $CFG->preventexecpath = true; will prevent these settings being changed in the Web UI.

You can add the following to config.php to set the settings there.

$CFG->forced_plugin_settings = [
  'videoassessment' => [
    'videoformat' => '.mp4',
    'ffmpegcommand' => '/usr/bin/ffmpeg -i {INPUT} {OUTPUT}',
    'ffmpegthumbnailcommand' => '/usr/bin/ffmpeg -i {INPUT} -vframes 1 -s 137x91 -ss 1 {OUTPUT}',
    'mp4boxcommand' => '',
    'backupusers' => '0',
    'preventvideouploads' => '1',
  ],
];